### PR TITLE
Fix CLI usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,25 @@
 {
   "name": "custom-element-types",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "custom-element-types",
-      "version": "0.2.3",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
+        "fs-extra": "10.1.0",
         "yargs": "17.5.1"
+      },
+      "bin": {
+        "cet": "index.js",
+        "custom-element-types": "index.js"
       },
       "devDependencies": {
         "@types/fs-extra": "9.0.13",
         "cpy-cli": "4.1.0",
         "custom-elements-manifest": "1.0.0",
-        "fs-extra": "10.1.0",
         "typescript": "4.7.4"
       }
     },
@@ -425,7 +429,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -483,8 +486,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
-      "dev": true
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -618,7 +620,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1327,7 +1328,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1759,7 +1759,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1802,8 +1801,7 @@
     "graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
-      "dev": true
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -1904,7 +1902,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -2365,8 +2362,7 @@
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "custom-element-types",
   "version": "0.2.6",
   "description": "A generator to create TypeScript type definitions for React applications using Custom Elements.",
+  "bin": {
+    "cet": "./index.js",
+    "custom-element-types": "./index.js"
+  },
   "main": "./index.js",
   "module": "./index.js",
   "typings": "./index.d.ts",
@@ -46,10 +50,10 @@
     "@types/fs-extra": "9.0.13",
     "cpy-cli": "4.1.0",
     "custom-elements-manifest": "1.0.0",
-    "fs-extra": "10.1.0",
     "typescript": "4.7.4"
   },
   "dependencies": {
+    "fs-extra": "10.1.0",
     "yargs": "17.5.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import fs from 'fs-extra';
 import path from 'path';
 import yargs from 'yargs';


### PR DESCRIPTION
Hi, I really look forward to introduce a tooling like this for our component libraries. Unfortunately, the described usage in the readme didn't work for me, so I'd suggest some minor changes :)

- to provide a binary entrypoint for the cli tool one needs to declare it in the manifest
- the entry file for the `bin` [needs to have a shebang](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#bin) declared
- as the `fs-extra` package is used at runtime, it's a `dependency` not a `devDependency`.